### PR TITLE
[LMM] Introduce resource persistency counters

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -1658,6 +1658,10 @@ void WrappedOpenGL::SwapBuffers(void *windowHandle)
   if(IsBackgroundCapturing(m_State))
     RenderDoc::Inst().Tick();
 
+  // Update persistency counters of the tracked resources.
+  if(RenderDoc::Inst().GetCaptureOptions().lowMemoryMode)
+    GetResourceManager()->IncrementPersistencyCounters();
+
   // don't do anything if no context is active.
   if(m_ActiveContexts[Threading::GetCurrentID()].ctx == NULL)
   {

--- a/renderdoc/driver/gl/gl_manager.h
+++ b/renderdoc/driver/gl/gl_manager.h
@@ -239,6 +239,11 @@ public:
   void MarkVAOReferenced(GLResource res, FrameRefType ref, bool allowFake0 = false);
   void MarkFBOReferenced(GLResource res, FrameRefType ref);
 
+  std::vector<GLResource> GetFBOAttachmentsByType(GLResource res, RDCGLenum attachmentType);
+  std::vector<GLResource> GetFBOTextures(GLResource res);
+
+  bool IsResourceTrackedForPersistency(const GLResource &res);
+
   void Force_ReferenceViews();
 
   template <typename SerialiserType>

--- a/renderdoc/driver/gl/wrappers/gl_framebuffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_framebuffer_funcs.cpp
@@ -1471,6 +1471,17 @@ void WrappedOpenGL::glBindFramebuffer(GLenum target, GLuint framebuffer)
 {
   SERIALISE_TIME_CALL(GL.glBindFramebuffer(target, framebuffer));
 
+  if(RenderDoc::Inst().GetCaptureOptions().lowMemoryMode)
+  {
+    std::vector<GLResource> fboTextures =
+        GetResourceManager()->GetFBOTextures(FramebufferRes(GetCtx(), framebuffer));
+
+    for(const GLResource &texture : fboTextures)
+    {
+      GetResourceManager()->ResetPersistencyCounter(GetResourceManager()->GetID(texture));
+    }
+  }
+
   if(IsActiveCapturing(m_State))
   {
     USE_SCRATCH_SERIALISER();


### PR DESCRIPTION
**Resource persistency counters** keep track of how long a resource is still used within a set of frames.

The threshold value when a resource become "persistent" is determined by the `PERSISTENT_RESOURCE_FRAMES_COUNT` (currently 100 frames; later can be passed as an option).

Not every resource is tracked for persistency. Only specific functions influence/reset the counters for specific resources. Currently this is only for textures used in frame buffer objects.

This diff supports only GL's `glBindFramebuffer`, Vulkan support will be in the follow up diffs. On binding a frame buffer, all its textures are reset for persistency counters. 

The counters are updated on each "frame end" event (in the GL's `SwapBuffers`).

**Why is this needed?**

In [Low Memory Mode](https://github.com/DmitrySoshnikov/renderdoc/pull/2), if a resource is persistent, we won't be copying it during capture, and can reuse from the original location.