### PR TITLE
[LMM] Postpone resource preparation until serialization to RDC file

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -2068,6 +2068,9 @@ bool WrappedOpenGL::EndFrameCapture(void *dev, void *wnd)
 
     GetResourceManager()->FreeInitialContents();
 
+    GetResourceManager()->ClearPersistencyCounters();
+
+
     for(auto it = m_CoherentMaps.begin(); it != m_CoherentMaps.end(); ++it)
     {
       GLResourceRecord *record = *it;


### PR DESCRIPTION
Prerequisite:

- [Part 1: Low Memory mode option and checkbox](https://github.com/DmitrySoshnikov/renderdoc/pull/2)
- [Part 2: Resource persistency counters](https://github.com/DmitrySoshnikov/renderdoc/pull/3)

Now when we track persistent resources, we can postpone their preparation in the main `PrepareInitialContents`.

Later in `InsertInitialContentsChunks` we load postponed resources via `Prepare_ResourceInitialStateIfNeeded`. Once such resource is serialized, we "unload" it by replacing with the empty `InitialContentData()`, which frees the previous initial contents for this resource ID.

This on average save ~18-22% of memory during active capturing.