### PR TITLE
[LMM] Use persistency whitelist based on resource age for postponed preparation

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -1856,6 +1856,8 @@ void WrappedOpenGL::StartFrameCapture(void *dev, void *wnd)
 
   m_State = CaptureState::ActiveCapturing;
 
+  GetResourceManager()->ResetCaptureStartTime();
+
   m_AppControlledCapture = true;
 
   m_Failures = 0;
@@ -2071,6 +2073,7 @@ bool WrappedOpenGL::EndFrameCapture(void *dev, void *wnd)
     m_State = CaptureState::BackgroundCapturing;
 
     GetResourceManager()->ClearPersistencyCounters();
+    GetResourceManager()->ResetLastWriteTimes();
 
     GetResourceManager()->MarkUnwrittenResources();
 

--- a/renderdoc/driver/gl/gl_manager.cpp
+++ b/renderdoc/driver/gl/gl_manager.cpp
@@ -129,8 +129,8 @@ std::vector<GLResource> GLResourceManager::GetFBOTextures(GLResource res)
   return GetFBOAttachmentsByType(res, eGL_TEXTURE);
 }
 
-bool GLResourceManager::IsResourceTrackedForPersistency(const GLResource &res) {
-  return res.Namespace == eResTexture;
+bool GLResourceManager::IsResourceTrackedForPersistency(const GLResource &_res) {
+  return true;
 }
 
 void GLResourceManager::MarkFBOReferenced(GLResource res, FrameRefType ref)

--- a/renderdoc/driver/gl/gl_manager.h
+++ b/renderdoc/driver/gl/gl_manager.h
@@ -215,6 +215,15 @@ public:
   using ResourceManager::MarkDirtyResource;
 
   void MarkDirtyResource(GLResource res) { return ResourceManager::MarkDirtyResource(GetID(res)); }
+
+  // Mark resource as dirty and write-referenced.
+  // Write-referenced resources are used to track resource "age".
+  void MarkDirtyWithWriteReference(GLResource res)
+  {
+    MarkResourceFrameReferenced(res, eFrameRef_ReadBeforeWrite);
+    MarkDirtyResource(res);
+  }
+
   void RegisterSync(ContextPair &ctx, GLsync sync, GLuint &name, ResourceId &id)
   {
     name = (GLuint)Atomic::Inc64(&m_SyncName);

--- a/renderdoc/driver/gl/gl_renderstate.cpp
+++ b/renderdoc/driver/gl/gl_renderstate.cpp
@@ -553,7 +553,7 @@ void GLRenderState::MarkDirty(WrappedOpenGL *driver) const
       GL.glGetIntegeri_v(eGL_IMAGE_BINDING_NAME, i, (GLint *)&name);
 
       if(name)
-        manager->MarkDirtyResource(TextureRes(ctx, name));
+        manager->MarkDirtyWithWriteReference(TextureRes(ctx, name));
     }
   }
 
@@ -606,7 +606,7 @@ void GLRenderState::MarkDirty(WrappedOpenGL *driver) const
         if(type == eGL_RENDERBUFFER)
           manager->MarkDirtyResource(RenderbufferRes(ctx, name));
         else
-          manager->MarkDirtyResource(TextureRes(ctx, name));
+          manager->MarkDirtyWithWriteReference(TextureRes(ctx, name));
       }
     }
 
@@ -620,7 +620,7 @@ void GLRenderState::MarkDirty(WrappedOpenGL *driver) const
       if(type == eGL_RENDERBUFFER)
         manager->MarkDirtyResource(RenderbufferRes(ctx, name));
       else
-        manager->MarkDirtyResource(TextureRes(ctx, name));
+        manager->MarkDirtyWithWriteReference(TextureRes(ctx, name));
     }
 
     GL.glGetFramebufferAttachmentParameteriv(eGL_DRAW_FRAMEBUFFER, eGL_STENCIL_ATTACHMENT,
@@ -633,7 +633,7 @@ void GLRenderState::MarkDirty(WrappedOpenGL *driver) const
       if(type == eGL_RENDERBUFFER)
         manager->MarkDirtyResource(RenderbufferRes(ctx, name));
       else
-        manager->MarkDirtyResource(TextureRes(ctx, name));
+        manager->MarkDirtyWithWriteReference(TextureRes(ctx, name));
     }
   }
 }

--- a/renderdoc/driver/gl/wrappers/gl_framebuffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_framebuffer_funcs.cpp
@@ -212,6 +212,7 @@ void WrappedOpenGL::glNamedFramebufferTextureEXT(GLuint framebuffer, GLenum atta
         m_HighTrafficResources.insert(record->GetResourceID());
         GetResourceManager()->MarkDirtyResource(record->GetResourceID());
       }
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
     }
     else
     {
@@ -258,6 +259,8 @@ void WrappedOpenGL::glFramebufferTexture(GLenum target, GLenum attachment, GLuin
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -341,6 +344,8 @@ void WrappedOpenGL::glNamedFramebufferTexture1DEXT(GLuint framebuffer, GLenum at
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 10)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -394,6 +399,8 @@ void WrappedOpenGL::glFramebufferTexture1D(GLenum target, GLenum attachment, GLe
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -477,6 +484,8 @@ void WrappedOpenGL::glNamedFramebufferTexture2DEXT(GLuint framebuffer, GLenum at
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 10)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -530,6 +539,8 @@ void WrappedOpenGL::glFramebufferTexture2D(GLenum target, GLenum attachment, GLe
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -637,6 +648,8 @@ void WrappedOpenGL::glFramebufferTexture2DMultisampleEXT(GLenum target, GLenum a
     {
       record->AddChunk(scope.Get());
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record != m_DeviceRecord)
       {
         record->UpdateCount++;
@@ -724,6 +737,8 @@ void WrappedOpenGL::glNamedFramebufferTexture3DEXT(GLuint framebuffer, GLenum at
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 10)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -778,6 +793,8 @@ void WrappedOpenGL::glFramebufferTexture3D(GLenum target, GLenum attachment, GLe
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -859,6 +876,8 @@ void WrappedOpenGL::glNamedFramebufferRenderbufferEXT(GLuint framebuffer, GLenum
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 10)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -908,6 +927,8 @@ void WrappedOpenGL::glFramebufferRenderbuffer(GLenum target, GLenum attachment,
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -992,6 +1013,8 @@ void WrappedOpenGL::glNamedFramebufferTextureLayerEXT(GLuint framebuffer, GLenum
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 10)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -1045,6 +1068,8 @@ void WrappedOpenGL::glFramebufferTextureLayer(GLenum target, GLenum attachment, 
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -1161,6 +1186,8 @@ void WrappedOpenGL::glFramebufferTextureMultiviewOVR(GLenum target, GLenum attac
     {
       record->AddChunk(scope.Get());
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record != m_DeviceRecord)
       {
         record->UpdateCount++;
@@ -1274,6 +1301,8 @@ void WrappedOpenGL::glFramebufferTextureMultisampleMultiviewOVR(GLenum target, G
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -1419,6 +1448,9 @@ void WrappedOpenGL::glFramebufferReadBufferEXT(GLuint framebuffer, GLenum buf)
     ResourceRecord *record =
         GetResourceManager()->GetResourceRecord(FramebufferRes(GetCtx(), framebuffer));
     record->AddChunk(scope.Get());
+
+    GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
+                                            eFrameRef_ReadBeforeWrite);
   }
 }
 
@@ -1442,7 +1474,10 @@ void WrappedOpenGL::glReadBuffer(GLenum mode)
     else
     {
       if(readrecord)
+      {
         GetResourceManager()->MarkDirtyResource(readrecord->GetResourceID());
+        GetResourceManager()->MarkFBOReferenced(readrecord->Resource, eFrameRef_ReadBeforeWrite);
+      }
     }
   }
 }
@@ -1489,8 +1524,12 @@ void WrappedOpenGL::glBindFramebuffer(GLenum target, GLuint framebuffer)
     Serialise_glBindFramebuffer(ser, target, framebuffer);
 
     GetContextRecord()->AddChunk(scope.Get());
-    GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
-                                            eFrameRef_ReadBeforeWrite);
+  }
+
+  if(IsCaptureMode(m_State))
+  {
+      GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
+                                              eFrameRef_ReadBeforeWrite);
   }
 
   if(target == eGL_DRAW_FRAMEBUFFER || target == eGL_FRAMEBUFFER)
@@ -1553,6 +1592,8 @@ void WrappedOpenGL::glFramebufferDrawBufferEXT(GLuint framebuffer, GLenum buf)
     ResourceRecord *record =
         GetResourceManager()->GetResourceRecord(FramebufferRes(GetCtx(), framebuffer));
     record->AddChunk(scope.Get());
+    GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
+                                            eFrameRef_ReadBeforeWrite);
   }
 }
 
@@ -1576,7 +1617,10 @@ void WrappedOpenGL::glDrawBuffer(GLenum buf)
     else
     {
       if(drawrecord)
+      {
         GetResourceManager()->MarkDirtyResource(drawrecord->GetResourceID());
+        GetResourceManager()->MarkFBOReferenced(drawrecord->Resource, eFrameRef_ReadBeforeWrite);
+      }
     }
   }
 }
@@ -1639,6 +1683,9 @@ void WrappedOpenGL::glFramebufferDrawBuffersEXT(GLuint framebuffer, GLsizei n, c
     ResourceRecord *record =
         GetResourceManager()->GetResourceRecord(FramebufferRes(GetCtx(), framebuffer));
     record->AddChunk(scope.Get());
+
+    GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
+                                            eFrameRef_ReadBeforeWrite);
   }
 }
 
@@ -1665,7 +1712,10 @@ void WrappedOpenGL::glDrawBuffers(GLsizei n, const GLenum *bufs)
     else
     {
       if(drawrecord)
+      {
         GetResourceManager()->MarkDirtyResource(drawrecord->GetResourceID());
+        GetResourceManager()->MarkFBOReferenced(drawrecord->Resource, eFrameRef_ReadBeforeWrite);
+      }
     }
   }
 }
@@ -1945,6 +1995,10 @@ void WrappedOpenGL::glBlitNamedFramebuffer(GLuint readFramebuffer, GLuint drawFr
                                      srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 
     GetContextRecord()->AddChunk(scope.Get());
+  }
+
+  if(IsCaptureMode(m_State))
+  {
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), readFramebuffer),
                                             eFrameRef_ReadBeforeWrite);
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), drawFramebuffer),
@@ -1961,7 +2015,7 @@ void WrappedOpenGL::glBlitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLi
   SERIALISE_TIME_CALL(
       GL.glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter));
 
-  if(IsActiveCapturing(m_State))
+  if(IsCaptureMode(m_State))
   {
     GLuint readFramebuffer = 0, drawFramebuffer = 0;
 
@@ -1969,17 +2023,21 @@ void WrappedOpenGL::glBlitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLi
       readFramebuffer = GetCtxData().m_ReadFramebufferRecord->Resource.name;
     if(GetCtxData().m_DrawFramebufferRecord)
       drawFramebuffer = GetCtxData().m_DrawFramebufferRecord->Resource.name;
+    
+    if(IsActiveCapturing(m_State))
+    {
+      USE_SCRATCH_SERIALISER();
+      SCOPED_SERIALISE_CHUNK(gl_CurChunk);
+      Serialise_glBlitNamedFramebuffer(ser, readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1,
+        srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 
-    USE_SCRATCH_SERIALISER();
-    SCOPED_SERIALISE_CHUNK(gl_CurChunk);
-    Serialise_glBlitNamedFramebuffer(ser, readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1,
-                                     srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+      GetContextRecord()->AddChunk(scope.Get());
+    }
 
-    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), readFramebuffer),
-                                            eFrameRef_ReadBeforeWrite);
+      eFrameRef_ReadBeforeWrite);
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), drawFramebuffer),
-                                            eFrameRef_ReadBeforeWrite);
+      eFrameRef_ReadBeforeWrite);
   }
 }
 

--- a/renderdoc/driver/gl/wrappers/gl_sampler_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_sampler_funcs.cpp
@@ -288,6 +288,9 @@ void WrappedOpenGL::glSamplerParameteri(GLuint sampler, GLenum pname, GLint para
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
+                                                        eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 20)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -347,6 +350,9 @@ void WrappedOpenGL::glSamplerParameterf(GLuint sampler, GLenum pname, GLfloat pa
     {
       record->AddChunk(scope.Get());
       record->UpdateCount++;
+
+      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
+                                                        eFrameRef_ReadBeforeWrite);
 
       if(record->UpdateCount > 20)
       {
@@ -409,6 +415,9 @@ void WrappedOpenGL::glSamplerParameteriv(GLuint sampler, GLenum pname, const GLi
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
+                                                        eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 20)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -469,6 +478,9 @@ void WrappedOpenGL::glSamplerParameterfv(GLuint sampler, GLenum pname, const GLf
     {
       record->AddChunk(scope.Get());
       record->UpdateCount++;
+
+      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
+                                                        eFrameRef_ReadBeforeWrite);
 
       if(record->UpdateCount > 20)
       {
@@ -531,6 +543,9 @@ void WrappedOpenGL::glSamplerParameterIiv(GLuint sampler, GLenum pname, const GL
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
+                                                        eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 20)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -591,6 +606,9 @@ void WrappedOpenGL::glSamplerParameterIuiv(GLuint sampler, GLenum pname, const G
     {
       record->AddChunk(scope.Get());
       record->UpdateCount++;
+
+      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
+                                                        eFrameRef_ReadBeforeWrite);
 
       if(record->UpdateCount > 20)
       {


### PR DESCRIPTION
Prerequisite:

- [Part 1: Low Memory mode option and checkbox](https://github.com/DmitrySoshnikov/renderdoc/pull/2)
- [Part 2: Resource persistency counters](https://github.com/DmitrySoshnikov/renderdoc/pull/3)
- [Part 3: Postpone resource preparation until serialization to RDC file](https://github.com/DmitrySoshnikov/renderdoc/pull/4)

This PR extends the `IsResourcePersistent` with an extra and more conservative check `HasPersistentAge`.

The design approach:

- We track resources _"age"_, the time since the last _write-reference_ in a frame 
- Currently only for GL: in `GLRenderState::MarkDirty` we mark Texture resources unconditionally as frame referenced with `eFrameRef_ReadBeforeWrite` reference type
- This marking resets the resource age to current time
- Then the `HasPersistentAge` checks whether the resource is within the threshold for the age (currently 3000 ms), and is treated as "persistent", i.e. can be prepared postponed
- After serialization to RDC file all resources are reset back to empty (which unloads an actual prepared contents)
- If a resource is _written after_ it was postponed, it's _immediately_ prepared

Combined with other heuristics, this saves on average 25-30% of memory on prepare