### PR TITLE
[LMM] Unload all resources after serialization

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -2062,14 +2062,13 @@ bool WrappedOpenGL::EndFrameCapture(void *dev, void *wnd)
 
     m_State = CaptureState::BackgroundCapturing;
 
+    GetResourceManager()->ClearPersistencyCounters();
+
     GetResourceManager()->MarkUnwrittenResources();
 
     GetResourceManager()->ClearReferencedResources();
 
     GetResourceManager()->FreeInitialContents();
-
-    GetResourceManager()->ClearPersistencyCounters();
-
 
     for(auto it = m_CoherentMaps.begin(); it != m_CoherentMaps.end(); ++it)
     {


### PR DESCRIPTION
This unloads all the resources after serialization. Resetting back to an "empty" resource unloads previous actual contents:

```cpp
// Reset back to empty contents.
SetInitialContents(id, InitialContentData());
```

The content is unloaded, preserving the resource ID in the initial resources map, so further serialization for number of resources works correctly. At the end of capture the map is cleaned up by the `GetResourceManager()->FreeInitialContents()` call.

This diff also slightly refactors functions to accept directly `ResourceId id` instead of `const ResourceId &id`, since it encapsulates just one `uint64_t`, and can be passed by value.